### PR TITLE
feat: 동적라우팅 페이지에 대한 정적 페이지화 설정 추가

### DIFF
--- a/src/app/books/[id]/page.tsx
+++ b/src/app/books/[id]/page.tsx
@@ -1,5 +1,23 @@
 import BookDetails from '@/components/books/details';
 
+import type { Metadata } from 'next';
+
+export async function generateStaticParams() {
+  // TODO: 백엔드에서 동적 라우팅될 목록의 id 범위 불러오기
+  const tempIdArray = Array.from({ length: 10 }, (_, index) => ({
+    id: String(index + 1)
+  }));
+  return tempIdArray;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  // TODO: SEO를 위한 데이터 수정 필요
+  return {
+    title: '{book.title} | 그루 도서정보',
+    description: '{book.desciption.substring(0, 150)}'
+  };
+}
+
 function BookDetailsPage() {
   return <BookDetails />;
 }

--- a/src/app/groups/[id]/edit/page.tsx
+++ b/src/app/groups/[id]/edit/page.tsx
@@ -1,5 +1,23 @@
 import ReadingGroupEdit from '@/components/groups/edit';
 
+import type { Metadata } from 'next';
+
+export async function generateStaticParams() {
+  // TODO: 백엔드에서 동적 라우팅될 목록의 id 범위 불러오기
+  const tempIdArray = Array.from({ length: 10 }, (_, index) => ({
+    id: String(index + 1)
+  }));
+  return tempIdArray;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  // TODO: SEO를 위한 데이터 수정 필요
+  return {
+    title: '{group.groupName} | 그루 독서모임',
+    description: '{group.content.substring(0, 150)}'
+  };
+}
+
 function ReadingGroupEditPage() {
   return <ReadingGroupEdit />;
 }

--- a/src/app/groups/[id]/page.tsx
+++ b/src/app/groups/[id]/page.tsx
@@ -1,5 +1,23 @@
 import ReadingGroupDetails from '@/components/groups/details';
 
+import type { Metadata } from 'next';
+
+export async function generateStaticParams() {
+  // TODO: 백엔드에서 동적 라우팅될 목록의 id 범위 불러오기
+  const tempIdArray = Array.from({ length: 10 }, (_, index) => ({
+    id: String(index + 1)
+  }));
+  return tempIdArray;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  // TODO: SEO를 위한 데이터 수정 필요
+  return {
+    title: '{group.groupName} | 그루 독서모임',
+    description: '{group.content.substring(0, 150)}'
+  };
+}
+
 function ReadingGroupDetailsPage() {
   return <ReadingGroupDetails />;
 }

--- a/src/app/reviews/[id]/edit/page.tsx
+++ b/src/app/reviews/[id]/edit/page.tsx
@@ -1,5 +1,23 @@
 import ReviewEdit from '@/components/reviews/edit';
 
+import type { Metadata } from 'next';
+
+export async function generateStaticParams() {
+  // TODO: 백엔드에서 동적 라우팅될 목록의 id 범위 불러오기
+  const tempIdArray = Array.from({ length: 10 }, (_, index) => ({
+    id: String(index + 1)
+  }));
+  return tempIdArray;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  // TODO: SEO를 위한 데이터 수정 필요
+  return {
+    title: '{review.reviewTitle} | 그루 독후감',
+    description: '{review.reviewContent.substring(0, 150)}'
+  };
+}
+
 function ReviewEditPage() {
   return <ReviewEdit />;
 }

--- a/src/app/reviews/[id]/page.tsx
+++ b/src/app/reviews/[id]/page.tsx
@@ -1,5 +1,23 @@
 import ReviewDetails from '@/components/reviews/details';
 
+import type { Metadata } from 'next';
+
+export async function generateStaticParams() {
+  // TODO: 백엔드에서 동적 라우팅될 목록의 id 범위 불러오기
+  const tempIdArray = Array.from({ length: 10 }, (_, index) => ({
+    id: String(index + 1)
+  }));
+  return tempIdArray;
+}
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  // TODO: SEO를 위한 데이터 수정 필요
+  return {
+    title: '{review.reviewTitle} | 그루 독후감',
+    description: '{review.reviewContent.substring(0, 150)}'
+  };
+}
+
 function ReviewDetailsPage() {
   return <ReviewDetails />;
 }


### PR DESCRIPTION
# Pull Request - Frontend

## 🎯 Purpose

 S3를 통한 프론트엔드 정적파일 배포를 위해 동적 라우팅 페이지를 정적 페이지로 처리하기 위한 generateStaticParams 함수 추가

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] ♻️ 리팩토링
- [ ] 🎨 UI/UX 개선
- [ ] ⚙️ 환경설정

## 📋 작업 내용

동적 라우팅 페이지에 generateStaticParams 함수 추가

### 관련 이슈

Closes #10 

## ⚠️ 주의사항

- [x] 환경 변수 변경 없음
- [x] 기존 기능에 영향 없음
- [x] 의존성 추가/변경 없음
