### PR TITLE
로그인 상태 유지 및 페이지 접근 권한 제한을 위한 미들웨어 추가

### DIFF
--- a/src/apis/groo/auth.ts
+++ b/src/apis/groo/auth.ts
@@ -1,16 +1,32 @@
 import axiosGroo from '@/apis/groo/config';
-import { CommonResDTO, LoginReqBody } from '@/types';
+import { LoginReqBody, LoginResDTO, LogoutResDTO, ReissueTokenResDTO } from '@/types';
 
 export const auth = {
   // 로그인
-  login: async (data: LoginReqBody): Promise<CommonResDTO> => {
+  login: async (data: LoginReqBody): Promise<LoginResDTO> => {
     const response = await axiosGroo.post('/auth/login', data);
     return response.data;
   },
 
   // 로그아웃
-  logout: async () => {
+  logout: async (): Promise<LogoutResDTO> => {
     const response = await axiosGroo.post('/auth/logout');
     return response.data;
+  },
+
+  // 엑세스토큰 재발행
+  reissueToken: async (): Promise<ReissueTokenResDTO> => {
+    const response = await axiosGroo.post('/token-refresh');
+    return response.data;
+  },
+
+  // 프론트서버에서 엑세스토큰 재발행
+  reissueTokenInServer: async (refreshToken: string) => {
+    const response = await axiosGroo.post(
+      '/token-refresh',
+      {},
+      { headers: { Cookie: `refreshToken=${refreshToken}` } }
+    );
+    return response;
   }
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+
+import { fetchGroo } from '@/apis';
+import { devLogger } from '@/utils/dev-logger';
+
+import type { NextRequest } from 'next/server';
+
+export const config = {
+  // 아래 경로 외 모든 경로에서 미들웨어를 실행
+  // api, _next/static, _next/image, favicon.ico, chrome devtools 제외
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.well-known).*)']
+};
+
+export async function middleware(request: NextRequest) {
+  // 쿠키에 저장된 토큰값 불러오기
+  const accessToken = request.cookies.get('accessToken')?.value;
+  const refreshToken = request.cookies.get('refreshToken')?.value;
+
+  // 리다이렉트할 페이지 url
+  const loginUrl = new URL('/login', request.url);
+  const homeUrl = new URL('/', request.url);
+
+  // 현재 경로가 로그인하지 않은 사용자를 위한 페이지인 경우 (로그인, 회원가입, ID/PW찾기)
+  const { pathname } = request.nextUrl;
+  devLogger(`[Front MiddleWare] 접속 url: ${pathname}`);
+  const isAuthPage = pathname.startsWith('/login') || pathname.startsWith('/signup');
+  if (isAuthPage) {
+    if (accessToken) {
+      return NextResponse.redirect(homeUrl);
+    }
+    return NextResponse.next();
+  }
+
+  // accessToken이 있는 경우 통과
+  if (accessToken) {
+    return NextResponse.next();
+  }
+
+  // accessToken과 refreshToken 모두 없는 경우 로그인 페이지로 리디렉션
+  if (!refreshToken) {
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // accessToken은 없고 refreshToken만 있는 경우
+  try {
+    // accessToken 재발행 시도
+    const reissueResponse = await fetchGroo.auth.reissueTokenInServer(refreshToken);
+
+    // 재발행 성공시 'set-cookie' 값을 브라우저로 전달
+    const response = NextResponse.next();
+    const setCookieHeader = reissueResponse.headers['set-cookie'];
+    if (setCookieHeader) {
+      const cookieToSet = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
+      response.headers.set('Set-Cookie', cookieToSet);
+    }
+
+    return response;
+  } catch (error) {
+    devLogger('Middleware token reissue error');
+    devLogger(error);
+
+    // 기존에 있던 만료된 refreshToken 삭제 후 리다이렉트
+    const responseRedirect = NextResponse.redirect(loginUrl);
+    responseRedirect.cookies.delete('refreshToken');
+    return responseRedirect;
+  }
+}

--- a/src/types/auth/dto.ts
+++ b/src/types/auth/dto.ts
@@ -2,7 +2,10 @@ import { CommonResDTO } from '@/types';
 
 // 로그인
 export type LoginReqBody = { userId: string; password: string };
-export type LoginResDTO = CommonResDTO<null>;
+export type LoginResDTO = CommonResDTO<{ accessToken: string; refreshToken: string }>;
 
 // 로그아웃
 export type LogoutResDTO = CommonResDTO<null>;
+
+// 토큰 재발행
+export type ReissueTokenResDTO = CommonResDTO<string>;


### PR DESCRIPTION
# Pull Request - Frontend

## 🎯 Purpose

페이지별 접근 권한 설정 추가

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] ♻️ 리팩토링
- [ ] 🎨 UI/UX 개선
- [ ] ⚙️ 환경설정

## 📋 작업 내용

- 페이지 랜더링 전 미들웨어를 통한 accessToken 확인을 통해 로그인된 사용자인지 확인
- accessToken 없이 refreshToken만 보유중인 사용자는 토큰 재발행 요청 실행
- 두 토큰 모두 없는 경우 로그인 되지 않은 사용자로 식별
- 로그인한 사용자 접근 통제
  - 로그인, 회원가입, ID/PW찾기 페이지 접근 제한
  - 위 페이지 접속 시 홈 화면으로 리다이렉트
- 비로그인 사용자 접근 통제
  - 로그인, 회원가입, ID/PW찾기 페이지 외 다른 페이지 접근 제한
  - 접근 제한 페이지 접속 시 로그인 페이지로 리다이렉트

### 관련 이슈

Closes #45


## ⚠️ 주의사항

- [x] 환경 변수 변경 없음
- [x] 기존 기능에 영향 없음
- [x] 의존성 추가/변경 없음
