### PR TITLE
페이지 접속 및 이동에 따라 자동으로 내 정보 조회 로직 추가

### DIFF
--- a/src/apis/groo/user.ts
+++ b/src/apis/groo/user.ts
@@ -6,6 +6,7 @@ import {
   CommonResDTO,
   FindIdReqBody,
   FindIdResDTO,
+  GetMyInfoResDTO,
   SendEmailCodeReqQuery,
   SendEmailCodeResDTO,
   SignupReqBody,
@@ -51,6 +52,23 @@ export const user = {
   // 비밀번호 재설정
   changePassword: async (data: ChangePasswordReqBody): Promise<ChangePasswordResDTO> => {
     const response = await axiosGroo.post('/users/password', data);
+    return response.data;
+  },
+
+  // 내 정보 조회
+  getMyInfo: async (): Promise<GetMyInfoResDTO> => {
+    const response = await axiosGroo.get('/users');
+    return response.data;
+  },
+
+  // 프론트서버에서 내 정보 조회
+  getMyInfoInServer: async (token: {
+    accessToken: string;
+    refreshToken: string;
+  }): Promise<GetMyInfoResDTO> => {
+    const response = await axiosGroo.get('/users', {
+      headers: { Cookie: `accessToken=${token.accessToken}; refreshToken=${token.refreshToken}` }
+    });
     return response.data;
   }
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,12 @@
+import { Metadata } from 'next';
 import { Noto_Serif_KR } from 'next/font/google';
 import localFont from 'next/font/local';
+import { cookies } from 'next/headers';
 
-import type { Metadata } from 'next';
+import { fetchGroo } from '@/apis';
+import StoreInitializer from '@/components/setup/store-initializer';
+import { User } from '@/types';
+import { devLogger } from '@/utils/dev-logger';
 
 import '@/styles/tailwind.css';
 import '@/styles/globals.scss';
@@ -54,10 +59,41 @@ interface RootLayoutProps {
   children: React.ReactNode;
 }
 
-function RootLayout({ children }: Readonly<RootLayoutProps>) {
+/**
+ * 서버 컴포넌트에서 사용자 정보를 가져오는 함수.
+ * HttpOnly 쿠키는 서버 fetch 요청에 자동으로 포함됩니다.
+ */
+async function getMyInfo(): Promise<User | null> {
+  // 서버 컴포넌트에서 쿠키를 가져옵니다.
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+
+  // accessToken이 없으면 API를 호출하지 않고 null을 반환합니다.
+  if (!accessToken && !refreshToken) {
+    return null;
+  }
+
+  try {
+    const response = await fetchGroo.user.getMyInfoInServer({
+      accessToken: accessToken as string,
+      refreshToken: refreshToken as string
+    });
+    return response.data;
+  } catch (error) {
+    devLogger('내 정보 조회에 실패했습니다.', true);
+    devLogger(error, true);
+    return null;
+  }
+}
+
+async function RootLayout({ children }: Readonly<RootLayoutProps>) {
+  const myInfo = await getMyInfo();
+
   return (
     <html lang="ko">
       <body className={`${pretendard.variable} ${notoSerifKr.variable} ${seoulNotice.variable}`}>
+        <StoreInitializer user={myInfo} />
         {children}
       </body>
     </html>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -3,6 +3,7 @@
 import { Bell, CircleUserRound, Search } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useShallow } from 'zustand/shallow';
 
 import { fetchGroo } from '@/apis';
 import styles from '@/components/layout/header.module.scss';
@@ -15,10 +16,14 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 import { useModalState } from '@/hooks/useModal';
+import useBoundStore from '@/stores';
 import { devLogger } from '@/utils/dev-logger';
 
 function HeaderLayout() {
   const router = useRouter();
+
+  // 로그아웃 성공시 내 정보를 삭제하기 위한 액션
+  const { setMyInfo } = useBoundStore(useShallow((state) => ({ setMyInfo: state.setMyInfo })));
 
   // TODO: 기능 구현이 되지 않은 버튼들 알림 모달 열림 상태
   const [isNicknameModalOpen, setNicknameModalOpen, openNicknameModal] = useModalState(false);
@@ -32,6 +37,7 @@ function HeaderLayout() {
   const logoutHandler = async () => {
     try {
       await fetchGroo.auth.logout();
+      setMyInfo(null);
       router.push('/login');
     } catch (error) {
       devLogger('로그아웃 실패');

--- a/src/components/setup/store-initializer.tsx
+++ b/src/components/setup/store-initializer.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRef } from 'react';
+
+import useBoundStore from '@/stores';
+import { User } from '@/types';
+
+interface StoreInitializerProps {
+  user: User | null;
+}
+
+function StoreInitializer({ user }: StoreInitializerProps) {
+  const initialized = useRef(false);
+
+  if (!initialized.current) {
+    useBoundStore.getState().setMyInfo(user);
+    initialized.current = true;
+  }
+
+  return null;
+}
+
+export default StoreInitializer;

--- a/src/components/user/login.tsx
+++ b/src/components/user/login.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useShallow } from 'zustand/shallow';
 
 import { fetchGroo } from '@/apis';
 import BasicButton from '@/components/layout/button/basic';
@@ -9,10 +10,14 @@ import BasicInputContainer from '@/components/layout/input/basic/container';
 import BasicInputField from '@/components/layout/input/basic/field';
 import styles from '@/components/user/login.module.scss';
 import { useInputText } from '@/hooks/useInput';
+import useBoundStore from '@/stores';
 import { ApiError } from '@/utils/error/api';
 
 function Login() {
   const router = useRouter();
+
+  // 로그인 성공시 내 정보를 저장하기 위한 액션
+  const { setMyInfo } = useBoundStore(useShallow((state) => ({ setMyInfo: state.setMyInfo })));
 
   // 로그인 입력 폼의 value에 사용할 값과 onChange에 사용할 함수
   const [userId, changeUserId] = useInputText('');
@@ -36,6 +41,9 @@ function Login() {
       try {
         await fetchGroo.auth.login({ userId: userId, password: password });
         alert('로그인에 성공했습니다.');
+        const user = await fetchGroo.user.getMyInfo();
+        console.log(user);
+        setMyInfo(user.data);
         router.push('/');
       } catch (error) {
         if (error instanceof ApiError) {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,14 +1,16 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+import { createAuthSlice } from '@/stores/slices/auth';
 import { createFindIdSlice } from '@/stores/slices/find-login-data';
 import { createSignupSlice } from '@/stores/slices/signup';
-import { FindLoginDataSlice, SignupSlice } from '@/types';
+import { AuthSlice, FindLoginDataSlice, SignupSlice } from '@/types';
 
-export type BoundState = SignupSlice & FindLoginDataSlice;
+export type BoundState = AuthSlice & SignupSlice & FindLoginDataSlice;
 
 const useBoundStore = create<BoundState>()(
   devtools((...a) => ({
+    ...createAuthSlice(...a),
     ...createSignupSlice(...a),
     ...createFindIdSlice(...a)
   }))

--- a/src/stores/slices/auth.ts
+++ b/src/stores/slices/auth.ts
@@ -1,0 +1,12 @@
+import { StateCreator } from 'zustand';
+
+import { AuthSlice, AuthState } from '@/types';
+
+const initialAuthState: AuthState = {
+  myInfo: null
+};
+
+export const createAuthSlice: StateCreator<AuthSlice, [['zustand/devtools', never]]> = (set) => ({
+  ...initialAuthState,
+  setMyInfo: (user) => set({ myInfo: user }, false, 'auth/setMyInfo')
+});

--- a/src/stores/slices/find-login-data.ts
+++ b/src/stores/slices/find-login-data.ts
@@ -10,12 +10,13 @@ const initialFindIdState: FindLoginDataState = {
   }
 };
 
-export const createFindIdSlice: StateCreator<FindLoginDataSlice> = (set) => ({
+export const createFindIdSlice: StateCreator<FindLoginDataSlice, [['zustand/devtools', never]]> = (set) => ({
   ...initialFindIdState,
 
-  setFindLoginDataStep: (step: FindLoginDataStep) => set({ findLoginDataStep: step }),
+  setFindLoginDataStep: (step: FindLoginDataStep) =>
+    set({ findLoginDataStep: step }, false, 'findLoginData/setFindLoginDataStep'),
 
-  setFindIdState: (findId: FindId) => set({ findId: findId }),
+  setFindIdState: (findId: FindId) => set({ findId: findId }, false, 'findLoginData/setFindIdState'),
 
-  resetFindLoginDataState: () => set(initialFindIdState)
+  resetFindLoginDataState: () => set(initialFindIdState, false, 'findLoginData/resetFindLoginDataState')
 });

--- a/src/stores/slices/signup.ts
+++ b/src/stores/slices/signup.ts
@@ -35,22 +35,28 @@ const initialSignupState: SignupState = {
   }
 };
 
-export const createSignupSlice: StateCreator<SignupSlice> = (set, get) => ({
+export const createSignupSlice: StateCreator<SignupSlice, [['zustand/devtools', never]]> = (set, get) => ({
   ...initialSignupState,
 
-  setSignupStep: (step) => set({ signupStep: step }),
+  setSignupStep: (step) => set({ signupStep: step }, false, 'signup/setSignupStep'),
 
   setSignupInputField: (field, value) =>
-    set((state) => ({
-      signupInputField: {
-        ...state.signupInputField,
-        [field]: value
-      }
-    })),
+    set(
+      (state) => ({
+        signupInputField: {
+          ...state.signupInputField,
+          [field]: value
+        }
+      }),
+      false,
+      'signup/setSignupInputField'
+    ),
 
-  setSignupIdVerification: (idVerification) => set({ signupIdVerification: idVerification }),
+  setSignupIdVerification: (idVerification) =>
+    set({ signupIdVerification: idVerification }, false, 'signup/setSignupIdVerification'),
 
-  setSignupEmailVerification: (emailVerification) => set({ signupEmailVerification: emailVerification }),
+  setSignupEmailVerification: (emailVerification) =>
+    set({ signupEmailVerification: emailVerification }, false, 'signup/setSignupEmailVerification'),
 
   signupValidateAndVerifyField: () => {
     const { signupStep, signupInputField, signupIdVerification, signupEmailVerification } = get();
@@ -88,5 +94,5 @@ export const createSignupSlice: StateCreator<SignupSlice> = (set, get) => ({
     }
   },
 
-  resetSignupState: () => set(initialSignupState)
+  resetSignupState: () => set(initialSignupState, false, 'signup/resetSignupState')
 });

--- a/src/types/user/dto.ts
+++ b/src/types/user/dto.ts
@@ -34,3 +34,24 @@ export type FindIdResDTO = CommonResDTO<string>;
 // 비밀번호 재설정
 export type ChangePasswordReqBody = { userId: string; password1: string; password2: string };
 export type ChangePasswordResDTO = CommonResDTO;
+
+// 내 정보 조회
+export type User = {
+  userId: string;
+  password: string;
+  email: string;
+  nickname: string;
+  profileImage: string | null;
+  introduction: string | null;
+  gender: 'm' | 'f';
+  name: string;
+  birth: string;
+  createdAt: string;
+  withdrawalStatus: boolean;
+  withdrawalDate: string | null;
+  pwdChangedAt: string | null;
+  checkPrivacy: boolean;
+  checkService: boolean;
+  emailVerified: boolean;
+};
+export type GetMyInfoResDTO = CommonResDTO<User>;

--- a/src/types/user/index.ts
+++ b/src/types/user/index.ts
@@ -1,3 +1,4 @@
 export * from '@/types/user/dto';
 export * from '@/types/user/find-login-data';
 export * from '@/types/user/signup';
+export * from '@/types/user/user';

--- a/src/types/user/user.ts
+++ b/src/types/user/user.ts
@@ -1,0 +1,11 @@
+import { User } from '@/types';
+
+export interface AuthState {
+  myInfo: User | null;
+}
+
+export interface AuthActions {
+  setMyInfo: (user: User | null) => void;
+}
+
+export type AuthSlice = AuthState & AuthActions;


### PR DESCRIPTION
# Pull Request - Frontend

## 🎯 Purpose

로그인을 하게되면 JWT를 쿠키로 전달받게 되는데 쿠키에 설정된 HttpOnly옵션으로 인해 토큰값을 통해 유저 정보를 읽어올 수가 없어 페이지를 접속할때 백엔드에서 내 정보 조회가 필요

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [ ] ♻️ 리팩토링
- [ ] 🎨 UI/UX 개선
- [ ] ⚙️ 환경설정

## 📋 작업 내용

- zustand의 각각의 action에 대하여 이름 정의 (devtool에서 상태 변화 디버깅을 위하여)
- 도메인 접속, 로그인, 로그아웃시 내 정보 조회가 이루어지도록 기능 추가

### 관련 이슈

Closes #57 

### UI/UX 변경사항

<!-- 화면상 변경된 부분이 있다면 설명 -->

## ⚠️ 주의사항

- [x] 환경 변수 변경 없음
- [x] 기존 기능에 영향 없음
- [x] 의존성 추가/변경 없음
