### PR TITLE
프론트서버에서 보내는 요청 설정, 미들웨어 기능 수정, SSR 구현

### DIFF
--- a/src/apis/groo/auth.ts
+++ b/src/apis/groo/auth.ts
@@ -18,15 +18,5 @@ export const auth = {
   reissueToken: async (): Promise<ReissueTokenResDTO> => {
     const response = await axiosGroo.post('/token-refresh');
     return response.data;
-  },
-
-  // 프론트서버에서 엑세스토큰 재발행
-  reissueTokenInServer: async (refreshToken: string) => {
-    const response = await axiosGroo.post(
-      '/token-refresh',
-      {},
-      { headers: { Cookie: `refreshToken=${refreshToken}` } }
-    );
-    return response;
   }
 };

--- a/src/apis/groo/server/auth.ts
+++ b/src/apis/groo/server/auth.ts
@@ -1,0 +1,13 @@
+import createAxiosInServer from '@/apis/groo/server/config';
+import { setTokenInHeader } from '@/utils/cookie';
+
+export const auth = {
+  // 엑세스토큰 재발행
+  reissueToken: async (refreshToken: string) => {
+    const axiosGrooInServer = createAxiosInServer();
+    const headers = setTokenInHeader('', refreshToken);
+
+    const response = await axiosGrooInServer.post('/token-refresh', {}, { headers });
+    return response;
+  }
+};

--- a/src/apis/groo/server/book.ts
+++ b/src/apis/groo/server/book.ts
@@ -1,0 +1,14 @@
+import createAxiosInServer from '@/apis/groo/server/config';
+import { GetDailyQuoteResDTO, Token } from '@/types';
+import { setTokenInHeader } from '@/utils/cookie';
+
+export const book = {
+  // 오늘의 한 문장
+  getDailyQuote: async (token: Token): Promise<GetDailyQuoteResDTO> => {
+    const axiosGrooInServer = createAxiosInServer();
+    const headers = setTokenInHeader(token.accessToken, token.refreshToken);
+
+    const response = await axiosGrooInServer.get('/quotes/daily', { headers });
+    return response.data;
+  }
+};

--- a/src/apis/groo/server/config.ts
+++ b/src/apis/groo/server/config.ts
@@ -1,0 +1,83 @@
+import axios, { AxiosInstance, isAxiosError } from 'axios';
+
+import { devLogger } from '@/utils/dev-logger';
+import { ApiError } from '@/utils/error/api';
+
+const grooApiBaseURL = `${process.env.NEXT_PUBLIC_API_URL}${process.env.NEXT_PUBLIC_GROO_COMMON_PATH}`;
+
+/** 서버에서 Groo API 요청을 위한 axios 인스턴스 생성 */
+function createAxiosInServer(): AxiosInstance {
+  const axiosGrooInServer = axios.create({
+    baseURL: grooApiBaseURL,
+    timeout: 10 * 1000
+  });
+
+  // axios 요청 공통 설정
+  axiosGrooInServer.interceptors.request.use(
+    // axios 요청시 공통 작업
+    (config) => {
+      // 요청 발생시 로그 출력
+      devLogger(`[Groo Server API]|[Request Info]: ${config.method?.toUpperCase()} | ${config.url}`);
+
+      return config;
+    },
+    // axios 요청오류시 공통 작업
+    (error) => {
+      return Promise.reject(error);
+    }
+  );
+
+  // axios 응답 공통 설정
+  axiosGrooInServer.interceptors.response.use(
+    // axios 응답시 공통작업
+    (response) => {
+      // 응답 발생시 로그 출력
+      devLogger(
+        `[Groo Server API]|[Response Info]: ${response.status} | ${response.config.method?.toUpperCase()} | ${response.config.url}`
+      );
+
+      return response;
+    },
+    // axios 응답오류시 공통작업
+    async (error) => {
+      // axios 에러인지 확인
+      if (isAxiosError(error)) {
+        // 응답을 받은 경우 (응답 상태코드가 2xx가 아닌 경우)
+        if (error.response) {
+          const status = error.response.status;
+          const { method, url } = error.response.config;
+          const message = error.response.data?.message;
+          const data = error.response.data?.data;
+
+          devLogger(
+            `[Groo Server API]|[Response Error]: ${status} | ${method?.toUpperCase()} | ${url} | ${message}`,
+            true
+          );
+          throw new ApiError({
+            message: message,
+            status: status,
+            apiMessage: message,
+            apiData: data,
+            original: error
+          });
+        }
+
+        // 요청은 성공했으나, 응답이 없는 경우
+        if (error.request) {
+          devLogger('[Groo Server API]|[Response Error]: Failed to get a response', true);
+          throw new ApiError({
+            message: '서버에서 응답을 받지 못했습니다. 네트워크를 확인해주세요',
+            original: error
+          });
+        }
+      }
+
+      devLogger('[Groo Server API]|[Response Error]: Occuered unknown Error', true);
+      throw new ApiError({ message: '알 수 없는 오류가 발생했습니다.', original: error });
+    }
+  );
+
+  return axiosGrooInServer;
+}
+
+export default createAxiosInServer;

--- a/src/apis/groo/server/config.ts
+++ b/src/apis/groo/server/config.ts
@@ -72,7 +72,7 @@ function createAxiosInServer(): AxiosInstance {
         }
       }
 
-      devLogger('[Groo Server API]|[Response Error]: Occuered unknown Error', true);
+      devLogger('[Groo Server API]|[Response Error]: Occurred unknown Error', true);
       throw new ApiError({ message: '알 수 없는 오류가 발생했습니다.', original: error });
     }
   );

--- a/src/apis/groo/server/index.ts
+++ b/src/apis/groo/server/index.ts
@@ -1,7 +1,9 @@
 import { auth } from '@/apis/groo/server/auth';
+import { book } from '@/apis/groo/server/book';
 import { user } from '@/apis/groo/server/user';
 
 export const fetchGrooInServer = {
   auth: auth,
+  book: book,
   user: user
 };

--- a/src/apis/groo/server/index.ts
+++ b/src/apis/groo/server/index.ts
@@ -1,0 +1,7 @@
+import { auth } from '@/apis/groo/server/auth';
+import { user } from '@/apis/groo/server/user';
+
+export const fetchGrooInServer = {
+  auth: auth,
+  user: user
+};

--- a/src/apis/groo/server/user.ts
+++ b/src/apis/groo/server/user.ts
@@ -1,0 +1,14 @@
+import createAxiosInServer from '@/apis/groo/server/config';
+import { GetMyInfoResDTO, Token } from '@/types';
+import { setTokenInHeader } from '@/utils/cookie';
+
+export const user = {
+  // 내 정보 조회
+  getMyInfo: async (token: Token): Promise<GetMyInfoResDTO> => {
+    const axiosGrooInServer = createAxiosInServer();
+    const headers = setTokenInHeader(token.accessToken, token.refreshToken);
+
+    const response = await axiosGrooInServer.get('/users', { headers });
+    return response.data;
+  }
+};

--- a/src/apis/groo/user.ts
+++ b/src/apis/groo/user.ts
@@ -59,16 +59,5 @@ export const user = {
   getMyInfo: async (): Promise<GetMyInfoResDTO> => {
     const response = await axiosGroo.get('/users');
     return response.data;
-  },
-
-  // 프론트서버에서 내 정보 조회
-  getMyInfoInServer: async (token: {
-    accessToken: string;
-    refreshToken: string;
-  }): Promise<GetMyInfoResDTO> => {
-    const response = await axiosGroo.get('/users', {
-      headers: { Cookie: `accessToken=${token.accessToken}; refreshToken=${token.refreshToken}` }
-    });
-    return response.data;
   }
 };

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,4 @@
 export * from '@/apis/aladin';
 export * from '@/apis/groo';
+export * from '@/apis/groo/server';
 export * from '@/apis/library';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from 'next';
 import { Noto_Serif_KR } from 'next/font/google';
 import localFont from 'next/font/local';
-import { cookies } from 'next/headers';
+import { headers } from 'next/headers';
 
-import { fetchGroo } from '@/apis';
 import StoreInitializer from '@/components/setup/store-initializer';
 import { User } from '@/types';
 import { devLogger } from '@/utils/dev-logger';
@@ -59,36 +58,20 @@ interface RootLayoutProps {
   children: React.ReactNode;
 }
 
-/**
- * 서버 컴포넌트에서 사용자 정보를 가져오는 함수.
- * HttpOnly 쿠키는 서버 fetch 요청에 자동으로 포함됩니다.
- */
-async function getMyInfo(): Promise<User | null> {
-  // 서버 컴포넌트에서 쿠키를 가져옵니다.
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-  const refreshToken = cookieStore.get('refreshToken')?.value;
-
-  // accessToken이 없으면 API를 호출하지 않고 null을 반환합니다.
-  if (!accessToken && !refreshToken) {
-    return null;
-  }
-
-  try {
-    const response = await fetchGroo.user.getMyInfoInServer({
-      accessToken: accessToken as string,
-      refreshToken: refreshToken as string
-    });
-    return response.data;
-  } catch (error) {
-    devLogger('내 정보 조회에 실패했습니다.', true);
-    devLogger(error, true);
-    return null;
-  }
-}
-
 async function RootLayout({ children }: Readonly<RootLayoutProps>) {
-  const myInfo = await getMyInfo();
+  const headersList = await headers();
+  const userInfoHeader = headersList.get('x-user-info');
+
+  let myInfo: User | null = null;
+  if (userInfoHeader) {
+    try {
+      const decodedUserInfo = Buffer.from(userInfoHeader, 'base64').toString('utf-8');
+      myInfo = JSON.parse(decodedUserInfo);
+    } catch (error) {
+      devLogger('내 정보 디코딩 또는 파싱에 실패했습니다.', true);
+      devLogger(error, true);
+    }
+  }
 
   return (
     <html lang="ko">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,34 @@
+import { cookies } from 'next/headers';
+
+import { fetchAladin } from '@/apis/aladin';
+import { fetchGrooInServer } from '@/apis/groo/server';
 import BestsellerList from '@/components/home/bestseller';
 import TodaySentence from '@/components/home/today-sentence';
 import HeaderLayout from '@/components/layout/header';
 import MainLayout from '@/components/layout/main';
+import { getTokenInCookie } from '@/utils/cookie';
 
-function BookRecommendationPage() {
+async function BookRecommendationPage() {
+  // 서버 컴포넌트에서 쿠키를 가져옵니다.
+  const cookieStore = await cookies();
+  const token = getTokenInCookie(cookieStore);
+
+  // 데이터 페칭 (오늘의 한 문장, 베스트셀러)
+  const [quoteData, bestsellerResponse] = await Promise.all([
+    fetchGrooInServer.book.getDailyQuote(token),
+    fetchAladin.getBestSellers(16)
+  ]);
+
+  // 프롭으로 전달할 데이터
+  const initialQuoteData = quoteData || null;
+  const bestsellerBooks = bestsellerResponse.item || [];
+
   return (
     <>
       <HeaderLayout />
       <MainLayout>
-        <TodaySentence />
-        <BestsellerList />
+        <TodaySentence initialQuoteData={initialQuoteData.data} />
+        <BestsellerList books={bestsellerBooks} />
       </MainLayout>
     </>
   );

--- a/src/components/home/bestseller.tsx
+++ b/src/components/home/bestseller.tsx
@@ -1,44 +1,15 @@
-'use client';
-
 import Image from 'next/image';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
 
-import { fetchAladin } from '@/apis/aladin';
 import styles from '@/components/home/home.module.scss';
 import { AladinBestsellerItem } from '@/types/aladin/dto';
 import { formatBookAuthor, formatBookTitle } from '@/utils/format/string';
 
-function BestsellerList() {
-  const [books, setBooks] = useState<AladinBestsellerItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+interface BestsellerListProps {
+  books: AladinBestsellerItem[];
+}
 
-  useEffect(() => {
-    const fetchBooks = async () => {
-      try {
-        setIsLoading(true);
-        const response = await fetchAladin.getBestSellers(16);
-        setBooks(response.item);
-      } catch (err) {
-        setError('베스트셀러 목록을 불러오는 데 실패했습니다.');
-        console.error(err);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchBooks();
-  }, []);
-
-  if (isLoading) {
-    return <div>로딩 중...</div>;
-  }
-
-  if (error) {
-    return <div>{error}</div>;
-  }
-
+function BestsellerList({ books }: BestsellerListProps) {
   return (
     <section className={styles.bestseller}>
       <h1>베스트셀러</h1>

--- a/src/components/home/today-sentence.tsx
+++ b/src/components/home/today-sentence.tsx
@@ -10,8 +10,12 @@ import { DailyQuoteData } from '@/types';
 import { formatBookAuthor, formatBookTitle } from '@/utils/format/string';
 import { setMidnightTimer } from '@/utils/time';
 
-function TodaySentence() {
-  const [quoteData, setQuoteData] = useState<DailyQuoteData | null>(null);
+interface TodaySentenceProps {
+  initialQuoteData: DailyQuoteData | null;
+}
+
+function TodaySentence({ initialQuoteData }: TodaySentenceProps) {
+  const [quoteData, setQuoteData] = useState<DailyQuoteData | null>(initialQuoteData);
 
   useEffect(() => {
     const fetchQuote = async () => {
@@ -26,13 +30,10 @@ function TodaySentence() {
       }
     };
 
-    // 1. 최초 데이터 호출
-    fetchQuote();
-
-    // 2. 유틸 함수로 타이머 설정하고, cleanup 함수를 받아옴
+    // 유틸 함수로 타이머 설정하고, cleanup 함수를 받아옴
     const cleanup = setMidnightTimer(fetchQuote);
 
-    // 3. 컴포넌트 언마운트 시 cleanup 실행
+    // 컴포넌트 언마운트 시 cleanup 실행
     return cleanup;
   }, []);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,7 +68,6 @@ export async function middleware(request: NextRequest) {
           headers: requestHeaders
         }
       });
-      // return NextResponse.next();
     } catch (error) {
       // 토큰이 유효하지 않음. 아래 리프레시 로직으로 넘어감.
       devLogger('[Front MiddleWare] 유효하지 않은 엑세스토큰 보유중. 재발급 시도');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { fetchGroo } from '@/apis';
+import { fetchGrooInServer } from '@/apis';
 import { devLogger } from '@/utils/dev-logger';
 
 import type { NextRequest } from 'next/server';
@@ -16,52 +16,95 @@ export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get('accessToken')?.value;
   const refreshToken = request.cookies.get('refreshToken')?.value;
 
+  // 접속한 페이지 url
+  const { pathname } = request.nextUrl;
+  devLogger(`[Front MiddleWare] Path: ${pathname}`);
+
   // 리다이렉트할 페이지 url
   const loginUrl = new URL('/login', request.url);
   const homeUrl = new URL('/', request.url);
 
   // 현재 경로가 로그인하지 않은 사용자를 위한 페이지인 경우 (로그인, 회원가입, ID/PW찾기)
-  const { pathname } = request.nextUrl;
-  devLogger(`[Front MiddleWare] 접속 url: ${pathname}`);
   const isAuthPage = pathname.startsWith('/login') || pathname.startsWith('/signup');
   if (isAuthPage) {
     if (accessToken) {
-      return NextResponse.redirect(homeUrl);
+      // accessToken이 유효한지 검증
+      try {
+        await fetchGrooInServer.user.getMyInfo({
+          accessToken: accessToken ? accessToken : '',
+          refreshToken: refreshToken ? refreshToken : ''
+        });
+        // 유효하다면 홈으로 리다이렉트
+        devLogger(`[Front MiddleWare] 로그인된 사용자의 접속 시도: ${pathname}`);
+        devLogger('[Front MiddleWare] 메인페이지로 리다이렉트');
+        return NextResponse.redirect(homeUrl);
+      } catch (error) {
+        // 유효하지 않다면 페이지 진입 허용
+        devLogger(`[Front MiddleWare] 비로그인 사용자의 접속 시도: ${pathname}`);
+        return NextResponse.next();
+      }
     }
+    // 토큰이 없으면 페이지 진입 허용
+    devLogger(`[Front MiddleWare] 비로그인 사용자의 접속 시도: ${pathname}`);
     return NextResponse.next();
   }
 
   // accessToken이 있는 경우 통과
   if (accessToken) {
-    return NextResponse.next();
+    try {
+      const myInfo = await fetchGrooInServer.user.getMyInfo({
+        accessToken: accessToken ? accessToken : '',
+        refreshToken: refreshToken ? refreshToken : ''
+      });
+      // 토큰이 유효하므로 요청 헤더에 유저 정보를 담아 요청 계속 진행
+      devLogger(`[Front MiddleWare] 로그인된 사용자의 접속 시도: ${pathname}`);
+      const requestHeaders = new Headers(request.headers);
+
+      devLogger(JSON.stringify(myInfo.data));
+      const encodedUserInfo = Buffer.from(JSON.stringify(myInfo.data)).toString('base64');
+      requestHeaders.set('x-user-info', encodedUserInfo);
+      return NextResponse.next({
+        request: {
+          headers: requestHeaders
+        }
+      });
+      // return NextResponse.next();
+    } catch (error) {
+      // 토큰이 유효하지 않음. 아래 리프레시 로직으로 넘어감.
+      devLogger('[Front MiddleWare] 유효하지 않은 엑세스토큰 보유중. 재발급 시도');
+    }
   }
 
-  // accessToken과 refreshToken 모두 없는 경우 로그인 페이지로 리디렉션
-  if (!refreshToken) {
-    return NextResponse.redirect(loginUrl);
-  }
+  // accessToken이 없거나 유효하지 않으며, refreshToken은 있는 경우
+  if (refreshToken) {
+    try {
+      const reissueResponse = await fetchGrooInServer.auth.reissueToken(refreshToken);
+      const setCookieHeader = reissueResponse.headers['set-cookie'];
 
-  // accessToken은 없고 refreshToken만 있는 경우
-  try {
-    // accessToken 재발행 시도
-    const reissueResponse = await fetchGroo.auth.reissueTokenInServer(refreshToken);
+      if (!setCookieHeader) {
+        throw new Error("토큰 재발행 응답에 'Set-Cookie' 헤더가 없습니다.");
+      }
 
-    // 재발행 성공시 'set-cookie' 값을 브라우저로 전달
-    const response = NextResponse.next();
-    const setCookieHeader = reissueResponse.headers['set-cookie'];
-    if (setCookieHeader) {
+      devLogger('[Front MiddleWare] 토큰 재발행 성공');
+      const response = NextResponse.redirect(request.url);
+
       const cookieToSet = Array.isArray(setCookieHeader) ? setCookieHeader[0] : setCookieHeader;
       response.headers.set('Set-Cookie', cookieToSet);
+
+      return response;
+    } catch (error) {
+      devLogger('[Front MiddleWare] 토큰 재발행 실패', true);
+      devLogger(error, true);
+
+      // 기존에 있던 만료된 refreshToken 삭제 후 리다이렉트
+      const responseRedirect = NextResponse.redirect(loginUrl);
+      responseRedirect.cookies.delete('accessToken');
+      responseRedirect.cookies.delete('refreshToken');
+      return responseRedirect;
     }
-
-    return response;
-  } catch (error) {
-    devLogger('Middleware token reissue error');
-    devLogger(error);
-
-    // 기존에 있던 만료된 refreshToken 삭제 후 리다이렉트
-    const responseRedirect = NextResponse.redirect(loginUrl);
-    responseRedirect.cookies.delete('refreshToken');
-    return responseRedirect;
   }
+
+  // 모든 토큰이 없는 경우
+  devLogger(`[Front MiddleWare] 토큰이 없는 사용자의 접속 시도: ${pathname}`);
+  return NextResponse.redirect(loginUrl);
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,3 +2,8 @@ export type CommonResDTO<D = unknown> = {
   message: string;
   data: D;
 };
+
+export type Token = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,20 @@
+import { ReadonlyRequestCookies } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
+
+import { Token } from '@/types';
+
+/** 쿠키에서 헤더를 가져오는 함수 */
+export const getTokenInCookie = (cookieStore: ReadonlyRequestCookies): Token => {
+  const accessToken = cookieStore.get('accessToken')?.value;
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+
+  return { accessToken: accessToken ? accessToken : '', refreshToken: refreshToken ? refreshToken : '' };
+};
+
+/** nextjs서버에서 백엔드로 요청시 헤더의 쿠키에 토큰을 설정하는 함수 */
+export const setTokenInHeader = (accessToken: string, refreshToken: string) => {
+  if (accessToken && refreshToken)
+    return { Cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}` };
+  if (accessToken) return { Cookie: `accessToken=${accessToken}` };
+  if (refreshToken) return { Cookie: `refreshToken=${refreshToken}` };
+  return { Cookie: '' };
+};


### PR DESCRIPTION
# Pull Request - Frontend

## 🎯 Purpose

middleware와 SSR과 같이 프론트서버에서 백엔드API를 사용하기 위해 데이터 패칭을 할때에는 기존의 브라우저에서 사용하기 위해 만들어둔 기존 axiosGroo 인스턴스를 사용하는 것은 올바르지 못하다고 생각되어, 프론트서버에서 동작하는 새로운 axios 인스턴스 생성 함수 제작
추가로 데이터패칭을 서버사이드에서 미리 할 수 있도록 하여 SEO와 초기 화면 깜빡임에 대한 문제 해결

- [x] ✨ 새로운 기능 추가
- [ ] 🐛 버그 수정
- [ ] 📝 문서 업데이트
- [x] ♻️ 리팩토링
- [x] 🎨 UI/UX 개선
- [ ] ⚙️ 환경설정

## 📋 작업 내용

- createAxiosInServer()추가 - 서버에서 Groo API 요청을 위한 axios 인스턴스 생성 함수
- fetchGrooInServer 객체 추가 - 브라우저에서 요청을 보낼때처럼 백엔드 api 요청을 담고 있는 객체
- 미들웨어의 기능 수정
  - (기존)엑세스토큰 보유 여부 확인 -> (수정)유효한 엑세스 토큰인지 확인
  - 유효한 엑세스 토큰인 경우 사용자의 정보 조회 및 로그인, 회원가입 페이지 진입시 홈화면으로 리다이렉트
  - 유효하지 않은 토큰인 경우 로그인 페이지로 리다이렉트
  - 엑세스토큰만 없고 리프레시토큰이 있는 경우 토큰 재발급 요청을 진행한 후 성공시 페이지 재진입
- 오늘의 한문장, 베스트셀러 조회를 서버사이드에 할 수 있도록 수정

### 관련 이슈

Closes #65 

### UI/UX 변경사항

<!-- 화면상 변경된 부분이 있다면 설명 -->

## ⚠️ 주의사항

- [x] 환경 변수 변경 없음
- [x] 기존 기능에 영향 없음
- [x] 의존성 추가/변경 없음
